### PR TITLE
fix reference to redux devtools extension

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -11,7 +11,7 @@ const store = createStore(
     reactReduxFirebase(firebase, rrfConfig),
     reduxFirestore(firebase),
     process.env.NODE_ENV === 'development' &&
-    (window as any).__REDUX_DEVTOOLS_EXTENSION__()
+    (window as any).__REDUX_DEVTOOLS_EXTENSION__
       ? (window as any).__REDUX_DEVTOOLS_EXTENSION__()
       : (f: any) => f
   )


### PR DESCRIPTION
Error occured for developers who do not install redux devtools extension
since `__REDUX_DEVTOOLS_EXTENSION__` function runs though it is undefined.

ReduxのdevTools拡張機能がインストールされていなければエラーが発生します。
理由は三項演算子の判定時に`__REDUX_DEVTOOLS_EXTENSION__`を実行しているからです。
おそらくここはundefinedかどうか判定したかったのだと思います。