### PR TITLE
Fix minifest.json to rename app

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "ぷちょへんざ",
+  "name": "ぷちょへんざ",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
軽微な修正ですが、manifest.jsonがたぶんcreate-react-appしたときのままになっているみたいです。

![Screenshot from Gyazo](https://gyazo.com/f8cebbe3a088cf60ed70fd9138ad7b05/raw)